### PR TITLE
검색페이지 및 메인페이지 및 useInput, useMap 구현 완료

### DIFF
--- a/src/common/Button.js
+++ b/src/common/Button.js
@@ -12,8 +12,12 @@ export function ShortButton({ className, children }) {
   return <button className={classes}>{children}</button>;
 }
 
-export function SearchButton({ className, children }) {
+export function SearchButton({ className, children, onClick }) {
   const classes = `search ${className}`;
 
-  return <button className={classes}>{children}</button>;
+  return (
+    <button onClick={onClick} className={classes}>
+      {children}
+    </button>
+  );
 }

--- a/src/common/Searchinput.js
+++ b/src/common/Searchinput.js
@@ -1,12 +1,11 @@
-import { SearchButton } from './Button';
-
-function SearchInput() {
+export default function SearchInput({ onChange }) {
   return (
     <div>
-      <input className='searchBox' placeholder='검색어를 입력하세요.' />
-      <SearchButton>검색</SearchButton>
+      <input
+        className='searchBox'
+        placeholder='지역명을 입력하세요.'
+        onChange={onChange}
+      />
     </div>
   );
 }
-
-export default SearchInput;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,80 +1,20 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import useAxios from '../hooks/useAxios';
+import useMap from '../hooks/useMap';
 
 import './Map.css';
 
 export default function Map(data) {
-  const [point, setPoint] = useState({ x: '33.450936', y: '126.569477' });
-  const [showAll, setShowAll] = useState('only-auctions');
-  const navigate = useNavigate();
-  const kakao = window.kakao;
+  const { place } = useParams();
+  const [setShowAll, showAll] = useMap(data, place);
 
-  useEffect(() => {
-    const mapContainer = document.getElementById('map');
-
-    const mapOptions = {
-      center: new kakao.maps.LatLng(point.x, point.y),
-      level: 3,
-    };
-
-    const map = new kakao.maps.Map(mapContainer, mapOptions);
-    const zoomControl = new kakao.maps.ZoomControl();
-    map.addControl(zoomControl, kakao.maps.ControlPosition.RIGHT);
-
-    kakao.maps.event.addListener(map, 'dragend', getMaxDistance(map));
-    kakao.maps.event.addListener(map, 'zoom_changed', getMaxDistance(map));
-
-    for (let i = 0; i < data.length; i++) {
-      const markerPosition = new kakao.maps.LatLng(
-        data[i].latlng[0],
-        data[i].latlng[1],
-      );
-
-      const auctionMarker = new kakao.maps.Marker({
-        position: markerPosition,
-      });
-
-      auctionMarker.setMap(map);
-
-      kakao.maps.event.addListener(
-        auctionMarker,
-        'click',
-        showDetailPage(data[i]._id),
-      );
-    }
-  }, [point, showAll]);
-
-  const showDetailPage = (buildingId) => {
-    return function () {
-      navigate(`/detail/${buildingId}`);
-    };
-  };
-
-  const getMaxDistance = (map) => {
-    return async function () {
-      const polyLine = new kakao.maps.Polyline({
-        map: map,
-        path: [map.getBounds().getSouthWest(), map.getBounds().getNorthEast()],
-        strokeOpacity: 0,
-      });
-
-      const length = polyLine.getLength();
-      const center = map.getCenter();
-      const centerPoint = [center.Ma, center.La];
-
-      setPoint({ x: center.getLat(), y: center.getLng() });
-
-      await useAxios(
-        `/buildings/?coords=${centerPoint}&max-distance=${length}&show=${showAll}`,
-        'get',
-      );
-    };
+  const toggleShowAll = () => {
+    setShowAll(!showAll);
   };
 
   return (
     <div>
+      <button onClick={toggleShowAll}>asd</button>
       <div id='map' className='map' />
     </div>
   );

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 import useMap from '../hooks/useMap';
 
@@ -6,7 +6,8 @@ import './Map.css';
 
 export default function Map(data) {
   const { place } = useParams();
-  const [setShowAll, showAll] = useMap(data, place);
+  const newQuery = decodeURI(window.location.search).split('=')[1];
+  const [setShowAll, showAll] = useMap(data, place, newQuery);
 
   const toggleShowAll = () => {
     setShowAll(!showAll);

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -4,10 +4,10 @@ import useMap from '../hooks/useMap';
 
 import './Map.css';
 
-export default function Map(data) {
+export default function Map() {
   const { place } = useParams();
   const newQuery = decodeURI(window.location.search).split('=')[1];
-  const [setShowAll, showAll] = useMap(data, place, newQuery);
+  const [setShowAll, showAll] = useMap(place, newQuery);
 
   const toggleShowAll = () => {
     setShowAll(!showAll);

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,0 +1,22 @@
+import { SearchButton } from '../common/Button';
+import { useNavigate } from 'react-router-dom';
+
+import SearchInput from '../common/Searchinput';
+import useInput from '../hooks/useInput';
+
+function Search() {
+  const [place, onChange] = useInput('');
+  const navigate = useNavigate();
+
+  function onClick(event) {
+    navigate(`/search/${place}`);
+  }
+  return (
+    <div>
+      <SearchInput onChange={onChange}></SearchInput>
+      <SearchButton onClick={onClick}></SearchButton>
+    </div>
+  );
+}
+
+export default Search;

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,20 +1,62 @@
 import { SearchButton } from '../common/Button';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useState } from 'react';
 
 import SearchInput from '../common/Searchinput';
 import useInput from '../hooks/useInput';
 
 function Search() {
-  const [place, onChange] = useInput('');
+  const [input, onChange] = useInput('');
+  const [filterType, setFilterType] = useState([]);
+  const { place } = useParams();
+
   const navigate = useNavigate();
 
-  function onClick(event) {
-    navigate(`/search/${place}`);
-  }
+  const serachRegion = () => {
+    navigate(`/search/${input}?type=${filterType}`);
+  };
+
+  const addFilterType = (event) => {
+    let query = decodeURI(window.location.search).split('=')[1];
+    if (window.location.href.includes('search')) {
+      if (query.includes(event.target.innerText)) {
+        const newQuery = newQuery.replace(event.target.innerText, '');
+
+        navigate(`/search/${place}?type=${newQuery}`);
+      } else {
+        const newFilterType = [...query];
+        newFilterType.push(event.target.innerText);
+
+        navigate(`/search/${place}?type=${newFilterType.join('')}`);
+      }
+    } else {
+      if (filterType.includes(event.target.innerText)) {
+        const newFilterType = [...filterType];
+        for (let i = 0; i < newFilterType.length; i++) {
+          if (newFilterType[i] === event.target.innerText) {
+            newFilterType.splice(i, 1);
+            i--;
+          }
+        }
+
+        setFilterType([...newFilterType]);
+      } else {
+        const newFilterType = [...filterType];
+        newFilterType.push(event.target.innerText);
+
+        setFilterType([...newFilterType]);
+      }
+    }
+  };
+
   return (
     <div>
       <SearchInput onChange={onChange}></SearchInput>
-      <SearchButton onClick={onClick}></SearchButton>
+      <SearchButton onClick={serachRegion}></SearchButton>
+      <button onClick={addFilterType}>아파트</button>
+      <button onClick={addFilterType}>주택</button>
+      <button onClick={addFilterType}>오피스텔/원룸</button>
+      <button onClick={addFilterType}>다세대/다가구</button>
     </div>
   );
 }

--- a/src/hooks/useInput.js
+++ b/src/hooks/useInput.js
@@ -1,11 +1,11 @@
 import { useState, useCallback } from 'react';
 
 export default function useInput(initialPlace) {
-  const [input, setInput] = useState(initialPlace);
+  const [inputValue, setInputValue] = useState(initialPlace);
 
   const onChange = useCallback((event) => {
-    setInput(event.target.value);
+    setInputValue(event.target.value);
   }, []);
 
-  return [input, onChange];
+  return [inputValue, onChange];
 }

--- a/src/hooks/useInput.js
+++ b/src/hooks/useInput.js
@@ -1,11 +1,11 @@
 import { useState, useCallback } from 'react';
 
 export default function useInput(initialPlace) {
-  const [place, setplace] = useState(initialPlace);
+  const [input, setInput] = useState(initialPlace);
 
-  const onChange = useCallback((e) => {
-    setplace(e.target.value);
+  const onChange = useCallback((event) => {
+    setInput(event.target.value);
   }, []);
 
-  return [place, onChange];
+  return [input, onChange];
 }

--- a/src/hooks/useInput.js
+++ b/src/hooks/useInput.js
@@ -1,0 +1,11 @@
+import { useState, useCallback } from 'react';
+
+export default function useInput(initialPlace) {
+  const [place, setplace] = useState(initialPlace);
+
+  const onChange = useCallback((e) => {
+    setplace(e.target.value);
+  }, []);
+
+  return [place, onChange];
+}

--- a/src/hooks/useMap.js
+++ b/src/hooks/useMap.js
@@ -2,11 +2,12 @@ import { useEffect, useState } from 'react';
 import useAxios from './useAxios';
 import { useNavigate } from 'react-router-dom';
 
-export default function useMap(data, place) {
+export default function useMap(data, place, type) {
   const [map, setMap] = useState();
   const [auctions, setAuctions] = useState([]);
   const [forSales, setforSales] = useState([]);
   const [showAll, setShowAll] = useState(false);
+
   const forSalesMarkers = [];
   const infoWindowArray = [];
 
@@ -24,8 +25,8 @@ export default function useMap(data, place) {
     };
 
     const map = new kakao.maps.Map(mapContainer, mapOptions);
-    setMap(map);
     const geocoder = new kakao.maps.services.Geocoder();
+    setMap(map);
 
     setAuctionsMarker(map);
     setForSalesMarker(map);
@@ -35,6 +36,7 @@ export default function useMap(data, place) {
         const searchCoords = new kakao.maps.LatLng(result[0].y, result[0].x);
 
         map.setCenter(searchCoords);
+
         getMaxDistance(map);
       }
     });
@@ -46,7 +48,7 @@ export default function useMap(data, place) {
     }
 
     kakao.maps.event.addListener(map, 'center_changed', getMaxDistance(map));
-  }, [place, auctions, forSales, showAll]);
+  }, [place, auctions, forSales, showAll, type]);
 
   const getMaxDistance = (map) => {
     return async function () {
@@ -65,7 +67,8 @@ export default function useMap(data, place) {
         'get',
       );
 
-      setAuctions(buildings.auction);
+      const newBuildings = auctionsFilter(buildings);
+      setAuctions(newBuildings.auction);
       setforSales(buildings.forSale);
     };
   };
@@ -113,6 +116,7 @@ export default function useMap(data, place) {
             forSales[i].name + forSales[i].squareMeters + forSales[i].Price,
           removable: true,
         });
+
         infoWindowArray.push(infoWindow);
 
         const forSalesMarker = new kakao.maps.Marker({
@@ -144,9 +148,31 @@ export default function useMap(data, place) {
       }
     }
   };
+
   const closeInfoWindow = () => {
     for (let i = 0; i < infoWindowArray.length; i++) {
       infoWindowArray[i].close();
+    }
+  };
+
+  const auctionsFilter = (buildings) => {
+    if (buildings) {
+      const newBuildings = [...buildings];
+
+      if (type) {
+        const typeArray = type.split[','];
+        const newAuctionsArray = [];
+
+        for (let i = 0; i < newBuildings.length; ) {
+          if (typeArray.includes(newBuildings[i].buildingType)) {
+            newAuctionsArray.push(newBuildings[i]);
+          }
+        }
+
+        return newAuctionsArray;
+      }
+
+      return newBuildings;
     }
   };
 

--- a/src/hooks/useMap.js
+++ b/src/hooks/useMap.js
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import useAxios from './useAxios';
+import { useNavigate } from 'react-router-dom';
+
+export default function useMap(data, place) {
+  const [map, setMap] = useState();
+  const [auctions, setAuctions] = useState([]);
+  const [forSales, setforSales] = useState([]);
+  const [showAll, setShowAll] = useState(false);
+  const forSalesMarkers = [];
+  const infoWindowArray = [];
+
+  const navigate = useNavigate();
+  const kakao = window.kakao;
+
+  useEffect(() => {
+    const mapContainer = document.getElementById('map');
+
+    const mapOptions = {
+      center: new kakao.maps.LatLng(37.51431716812058, 127.06282762463266),
+      level: 3,
+      draggable: true,
+      scrollwheel: true,
+    };
+
+    const map = new kakao.maps.Map(mapContainer, mapOptions);
+    setMap(map);
+    const geocoder = new kakao.maps.services.Geocoder();
+
+    setAuctionsMarker(map);
+    setForSalesMarker(map);
+
+    geocoder.addressSearch(place, (result, status) => {
+      if (status === kakao.maps.services.Status.OK) {
+        const searchCoords = new kakao.maps.LatLng(result[0].y, result[0].x);
+
+        map.setCenter(searchCoords);
+        getMaxDistance(map);
+      }
+    });
+
+    if (showAll) {
+      ShowForSaleMarkers(map);
+    } else {
+      deleteForSaleMarkers(map);
+    }
+
+    kakao.maps.event.addListener(map, 'center_changed', getMaxDistance(map));
+  }, [place, auctions, forSales, showAll]);
+
+  const getMaxDistance = (map) => {
+    return async function () {
+      const polyLine = new kakao.maps.Polyline({
+        map: map,
+        path: [map.getBounds().getSouthWest(), map.getBounds().getNorthEast()],
+        strokeOpacity: 0,
+      });
+
+      const length = polyLine.getLength();
+      const center = map.getCenter();
+      const centerPoint = [center.Ma, center.La];
+
+      const buildings = await useAxios(
+        `/buildings/?coords=${centerPoint}&max-distance=${length}`,
+        'get',
+      );
+
+      setAuctions(buildings.auction);
+      setforSales(buildings.forSale);
+    };
+  };
+
+  const showDetailPage = (buildingId) => {
+    return function () {
+      navigate(`/detail/${buildingId}`);
+    };
+  };
+
+  const setAuctionsMarker = (map) => {
+    if (auctions) {
+      for (let i = 0; i < auctions.length; i++) {
+        const markerPosition = new kakao.maps.LatLng(
+          auctions[i].coords[0],
+          auctions[i].coords[1],
+        );
+
+        const auctionMarker = new kakao.maps.Marker({
+          position: markerPosition,
+        });
+
+        auctionMarker.setMap(map);
+
+        kakao.maps.event.addListener(
+          auctionMarker,
+          'click',
+          showDetailPage(auctions[i]._id),
+        );
+      }
+    }
+  };
+
+  const setForSalesMarker = (map) => {
+    if (forSales) {
+      for (let i = 0; i < forSales.length; i++) {
+        const markerPosition = new kakao.maps.LatLng(
+          forSales[i].coords[0],
+          forSales[i].coords[1],
+        );
+
+        const infoWindow = new kakao.maps.InfoWindow({
+          position: markerPosition,
+          content:
+            forSales[i].name + forSales[i].squareMeters + forSales[i].Price,
+          removable: true,
+        });
+        infoWindowArray.push(infoWindow);
+
+        const forSalesMarker = new kakao.maps.Marker({
+          position: markerPosition,
+        });
+
+        forSalesMarkers.push(forSalesMarker);
+
+        kakao.maps.event.addListener(forSalesMarker, 'click', () => {
+          closeInfoWindow();
+          infoWindow.open(map, forSalesMarker);
+        });
+      }
+    }
+  };
+
+  const ShowForSaleMarkers = (map) => {
+    if (forSalesMarkers) {
+      for (let i = 0; i < forSalesMarkers.length; i++) {
+        forSalesMarkers[i].setMap(map);
+      }
+    }
+  };
+
+  const deleteForSaleMarkers = () => {
+    if (forSalesMarkers) {
+      for (let i = 0; i < forSalesMarkers.length; i++) {
+        forSalesMarkers[i].setMap(null);
+      }
+    }
+  };
+  const closeInfoWindow = () => {
+    for (let i = 0; i < infoWindowArray.length; i++) {
+      infoWindowArray[i].close();
+    }
+  };
+
+  return [setShowAll, showAll];
+}

--- a/src/hooks/useMap.js
+++ b/src/hooks/useMap.js
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
-import useAxios from './useAxios';
 import { useNavigate } from 'react-router-dom';
 
-export default function useMap(data, place, type) {
+import useAxios from './useAxios';
+
+export default function useMap(place, type) {
   const [map, setMap] = useState();
   const [auctions, setAuctions] = useState([]);
   const [forSales, setforSales] = useState([]);
@@ -176,5 +177,5 @@ export default function useMap(data, place, type) {
     }
   };
 
-  return [setShowAll, showAll];
+  return [showAll, setShowAll];
 }

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,5 +1,9 @@
-function Main() {
-  return <div></div>;
-}
+import Search from '../components/Search';
 
-export default Main;
+export default function Main() {
+  return (
+    <div>
+      <Search></Search>
+    </div>
+  );
+}

--- a/src/pages/SearchPlace.js
+++ b/src/pages/SearchPlace.js
@@ -1,30 +1,10 @@
-import { useState } from 'react';
 import Map from '../components/Map';
+import Search from '../components/Search';
 
 export default function SearchPlace() {
-  const [inputText, setInputText] = useState('');
-  const [place, setPlace] = useState('');
-
-  const onChange = (event) => {
-    setInputText(event.target.value);
-  };
-
-  const handleSubmit = (event) => {
-    event.preventDefault();
-    setPlace(inputText);
-    setInputText('');
-  };
-
   return (
     <div>
-      <form className='inputForm' onSubmit={handleSubmit}>
-        <input
-          placeholder='Search Place...'
-          onChange={onChange}
-          value={inputText}
-        />
-        <button type='submit'>검색</button>
-      </form>
+      <Search></Search>
       <Map />
     </div>
   );

--- a/src/routes/Authorized.js
+++ b/src/routes/Authorized.js
@@ -1,7 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 
 import Main from '../pages/Main';
-import SearchPlace from '../pages/SearchPlace';
 import Detail from '../pages/Detail';
 
 export default function Authorized() {
@@ -9,7 +8,6 @@ export default function Authorized() {
     <Routes>
       <Route path='/' element={<Main />} />
       <Route path='/login' element={<Navigate replace to='/' />} />
-      <Route path='/search' element={<SearchPlace />} />
       <Route path='/detail/:buildingId' element={<Detail />} />
     </Routes>
   );

--- a/src/routes/Authorized.js
+++ b/src/routes/Authorized.js
@@ -1,14 +1,17 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 
-import Main from '../pages/Main';
 import Detail from '../pages/Detail';
+import Main from '../pages/Main';
+import SearchPlace from '../pages/SearchPlace';
 
 export default function Authorized() {
   return (
     <Routes>
-      <Route path='/' element={<Main />} />
       <Route path='/login' element={<Navigate replace to='/' />} />
       <Route path='/detail/:buildingId' element={<Detail />} />
+      <Route path='/' element={<Main />} />
+      <Route path='/search/:place' element={<SearchPlace />} />
+      <Route path='/search' element={<SearchPlace />} />
     </Routes>
   );
 }

--- a/src/routes/Unauthorized.js
+++ b/src/routes/Unauthorized.js
@@ -1,15 +1,12 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 
 import Login from '../pages/Login';
-import SearchPlace from '../pages/SearchPlace';
 
 export default function Unauthorized() {
   return (
     <Routes>
       <Route path='/' element={<Navigate replace to='/login' />} />
       <Route path='/login' element={<Login />} />
-      <Route path='/search/:place' element={<SearchPlace />} />
-      <Route path='/search' element={<SearchPlace />} />
     </Routes>
   );
 }

--- a/src/routes/Unauthorized.js
+++ b/src/routes/Unauthorized.js
@@ -1,12 +1,15 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 
 import Login from '../pages/Login';
+import SearchPlace from '../pages/SearchPlace';
 
 export default function Unauthorized() {
   return (
     <Routes>
       <Route path='/' element={<Navigate replace to='/login' />} />
       <Route path='/login' element={<Login />} />
+      <Route path='/search/:place' element={<SearchPlace />} />
+      <Route path='/search' element={<SearchPlace />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## 개요
useInput과, useMap 커스텀 훅을 만들었습니다
검색로직을 메인페이지와 검색페이지(지도) 에서 한컴포넌트로 재사용 했습니다.
url경로에 따라 onClick이 다른 함수를 가르키게 하는 방식으로 했습니다.
그후 쿼리와 param으로 검색어와 필터링을 해야되는 타입을 전달해
지도에서 바로바로 필터링하게 했습니다!
처음 지도에서 마커를 생성할때 관리하는 배열을 다르게 해서 토글 버튼으로 조절할 수 있게했습니다.
또한 모바일 터치를 의식해서 Dnd 에서 이벤트를 centerChanged로 다르게 주었습니다!


## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [x] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점
쿼리와 파람을 이용해 사용자가 검색하거나 필터링한 조건을 useMap 훅에서 알 수 있게 했습니다.


```js
navigate(`/search/${place}?type=${newQuery}`);

```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항

목데이터로 어느정도 검증은 했으나 실제 많은 데이터가 들어올경우는 아직 검증하지 않았습니다.
