### PR TITLE
useSearchTypeFilter 훅 생성

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -2,64 +2,20 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import useInput from '../hooks/useInput';
+import useSearchTypeFilter from '../hooks/useSearchTypeFilter';
+
 import NavBar from './NavBar';
 
 import './Search.scss';
 
-function Search() {
-  const [isChecked, setIsChecked] = useState({
-    apartment: false,
-    house: false,
-    studio: false,
-    multiUnit: false,
-  });
+export default function Search() {
   const [isHid, setIsHid] = useState(false);
   const [input, onChange] = useInput('');
-  const [filterType, setFilterType] = useState([]);
-
   const navigate = useNavigate();
+  const { filterType, isChecked, handleFilterType } = useSearchTypeFilter();
 
   const handleSearchRegion = () => {
     navigate(`/search/${input}?type=${filterType}`);
-  };
-
-  const handleAddFilterType = (event) => {
-    const targetDiv = event.target.closest(`div`);
-    const targetDivText = targetDiv.innerText;
-
-    if (filterType.includes(targetDivText)) {
-      const newFilterType = filterType.filter((type) => type !== targetDivText);
-      setFilterType(newFilterType);
-    } else {
-      setFilterType((prevState) => [...prevState, targetDivText]);
-    }
-
-    if (targetDivText === '아파트') {
-      setIsChecked(
-        (prevState) =>
-          (prevState = { ...prevState, apartment: !prevState.apartment }),
-      );
-    }
-
-    if (targetDivText === '주택') {
-      setIsChecked(
-        (prevState) => (prevState = { ...prevState, house: !prevState.house }),
-      );
-    }
-
-    if (targetDivText.includes('오피스텔')) {
-      setIsChecked(
-        (prevState) =>
-          (prevState = { ...prevState, studio: !prevState.studio }),
-      );
-    }
-
-    if (targetDivText.includes('다세대')) {
-      setIsChecked(
-        (prevState) =>
-          (prevState = { ...prevState, multiUnit: !prevState.multiUnit }),
-      );
-    }
   };
 
   const handleHideNavBar = () => {
@@ -76,7 +32,7 @@ function Search() {
         <img src='/img/logo.png' alt='logo' />
         <h4>Please select an auction area.</h4>
         <h4>Enter the administrative district of Seoul.</h4>
-        <div className='main-search-types' onClick={handleAddFilterType}>
+        <div className='main-search-types' onClick={handleFilterType}>
           <div
             style={{
               backgroundColor: isChecked.apartment && '#345ee7',
@@ -117,5 +73,3 @@ function Search() {
     </>
   );
 }
-
-export default Search;

--- a/src/hooks/useSearchTypeFilter.js
+++ b/src/hooks/useSearchTypeFilter.js
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+export default function useSearchTypeFilter() {
+  const [filterType, setFilterType] = useState([]);
+  const [isChecked, setIsChecked] = useState({
+    apartment: false,
+    house: false,
+    studio: false,
+    multiUnit: false,
+  });
+
+  const handleFilterType = (event) => {
+    const targetDiv = event.target.closest(`div`);
+    const targetDivText = targetDiv.innerText;
+
+    if (filterType.includes(targetDivText)) {
+      const newFilterType = filterType.filter((type) => type !== targetDivText);
+      setFilterType(newFilterType);
+    } else {
+      setFilterType((prevState) => [...prevState, targetDivText]);
+    }
+
+    if (targetDivText === '아파트') {
+      setIsChecked(
+        (prevState) =>
+          (prevState = { ...prevState, apartment: !prevState.apartment }),
+      );
+    }
+
+    if (targetDivText === '주택') {
+      setIsChecked(
+        (prevState) => (prevState = { ...prevState, house: !prevState.house }),
+      );
+    }
+
+    if (targetDivText.includes('오피스텔')) {
+      setIsChecked(
+        (prevState) =>
+          (prevState = { ...prevState, studio: !prevState.studio }),
+      );
+    }
+
+    if (targetDivText.includes('다세대')) {
+      setIsChecked(
+        (prevState) =>
+          (prevState = { ...prevState, multiUnit: !prevState.multiUnit }),
+      );
+    }
+  };
+
+  return {
+    filterType,
+    isChecked,
+    handleFilterType,
+  };
+}


### PR DESCRIPTION
## 개요

- 서치타입의 필터 로직을 훅으로 빼서 재사용이 되도록 만들었습니다

## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- 서치타입 필터 훅을 쓰실거면 다음과 같이 쓰시면 됩니다

```js
  const { filterType, isChecked, handleFilterType } = useSearchTypeFilter();

```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항

- 훅 구조에 변경이 필요하신 경우 알려주세요!
