### PR TITLE
유저관심빌딩 on/off 및 마이페이지 관심목록 추가 및 지도 클러스터 오류 fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2115,6 +2115,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@heroicons/react": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.6.tgz",
+      "integrity": "sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==",
+      "peerDependencies": {
+        "react": ">= 16"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -18322,6 +18330,12 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
+    },
+    "@heroicons/react": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-1.0.6.tgz",
+      "integrity": "sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==",
+      "requires": {}
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",

--- a/src/components/FavoriteBuildings.scss
+++ b/src/components/FavoriteBuildings.scss
@@ -13,7 +13,7 @@
   .concon {
     margin-top: 13px;
     background-color: #efefef;
-    color: #eee;
+    color: #000;
     border-radius: 5px;
     height: 65px;
   }

--- a/src/hooks/useMap.js
+++ b/src/hooks/useMap.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getGraphData } from '../utils/graph';
+import { debounce } from 'lodash';
 
 import useAxios from './useAxios';
 
@@ -10,7 +11,6 @@ export default function useMap(position, type, mapElement) {
   const [currentAddress, setCurrentAddress] = useState('');
   const [currentCenter, setCurrentCenter] = useState([37.5, 127.0]);
   const [graphData, setGraphData] = useState({});
-  const [a, setA] = useState('');
   const infoWindowArray = [];
   const auctionMarkers = [];
   const forSalesArray = [];
@@ -78,6 +78,7 @@ export default function useMap(position, type, mapElement) {
   }, [place, type, showAll]);
 
   const getMaxDistance = (map, geocoder) => {
+    kakao.maps.event.preventMap();
     return async function () {
       const polyLine = new kakao.maps.Polyline({
         map: map,
@@ -126,6 +127,7 @@ export default function useMap(position, type, mapElement) {
     const imageOption = { offset: new kakao.maps.Point(27, 69) };
 
     for (let i = 0; i < auctionMarkers.length; i++) {
+      cluster.removeMarker(auctionMarkers[i]);
       auctionMarkers[i].setMap(null);
     }
 
@@ -172,7 +174,7 @@ export default function useMap(position, type, mapElement) {
         content:
           forSalesArray[i].name +
           forSalesArray[i].squareMeters +
-          forSalesArray[i].Price,
+          forSalesArray[i].price,
         removable: true,
       });
 
@@ -216,6 +218,7 @@ export default function useMap(position, type, mapElement) {
 
   const auctionsFilter = (buildings) => {
     if (!buildings) return buildings;
+    console.log(type);
     if (type) {
       const newAuctionsArray = [];
 

--- a/src/pages/Detail.js
+++ b/src/pages/Detail.js
@@ -1,5 +1,12 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { BsHeart, BsHeartFill } from 'react-icons/bs';
+
+import {
+  addUserFavoriteBuilding,
+  deleteUserFavoriteBuilding,
+} from '../store/userSlice';
 
 import DetailSlides from '../components/DetailSlides';
 import Accordion from '../common/Accordion';
@@ -9,8 +16,18 @@ import NavBar from '../components/NavBar';
 import './Detail.scss';
 
 export default function Detail() {
+  const dispatch = useDispatch();
   const { buildingId } = useParams();
   const [detail, setDetail] = useState({ buildingInfo: {} });
+
+  const { favoriteBuildings } = useSelector(
+    (state) => state.user.userInformation,
+  );
+
+  const [userFavorite, setUserFavorite] = useState(
+    favoriteBuildings.includes(buildingId),
+  );
+
   const {
     buildingType,
     auctionNumber,
@@ -35,6 +52,22 @@ export default function Detail() {
     getBuildingDetail();
   }, []);
 
+  const handleUserFavoriteRegion = async () => {
+    if (userFavorite) {
+      await useAxios(`users/user/favorites/buildings/${buildingId}`, 'delete');
+
+      setUserFavorite(false);
+      dispatch(deleteUserFavoriteBuilding(buildingId));
+    } else {
+      await useAxios(`users/user/favorites/buildings`, 'post', {
+        buildingId: buildingId,
+      });
+
+      setUserFavorite(true);
+      dispatch(addUserFavoriteBuilding(buildingId));
+    }
+  };
+
   return (
     <>
       <div className='detail-container'>
@@ -42,6 +75,15 @@ export default function Detail() {
           <img src='/img/logo.png' alt='logo' />
         </div>
         <div className='detail-heading'>
+          {userFavorite ? (
+            <button onClick={handleUserFavoriteRegion}>
+              <BsHeartFill></BsHeartFill>
+            </button>
+          ) : (
+            <button onClick={handleUserFavoriteRegion}>
+              <BsHeart></BsHeart>
+            </button>
+          )}
           <div className='detail-icon'>
             {detail && <span>{buildingType}</span>}
           </div>

--- a/src/pages/Detail.scss
+++ b/src/pages/Detail.scss
@@ -3,6 +3,13 @@
   flex-direction: column;
   margin-bottom: 10vh;
 
+  & button {
+    margin-right: 10px;
+    background-color: #ffff;
+    border: 0px;
+    font-size: larger;
+  }
+
   & img {
     margin-bottom: 10px;
   }

--- a/src/store/userSlice.js
+++ b/src/store/userSlice.js
@@ -13,6 +13,15 @@ const userSlice = createSlice({
       const { fieldName, data } = action.payload;
       state.userInformation[fieldName] = data;
     },
+    addUserFavoriteBuilding(state, action) {
+      state.userInformation.favoriteBuildings.push(action.payload);
+    },
+    deleteUserFavoriteBuilding(state, action) {
+      const newFavorites = state.userInformation.favoriteBuildings.filter(
+        (element) => element !== action.payload,
+      );
+      state.userInformation.favoriteBuildings = newFavorites;
+    },
     addUserFavoriteRegion(state, action) {
       state.userInformation.favoriteRegions.push(action.payload);
     },
@@ -23,6 +32,8 @@ const userSlice = createSlice({
 });
 
 export const {
+  addUserFavoriteBuilding,
+  deleteUserFavoriteBuilding,
   saveUserInfo,
   deleteUserInfo,
   patchUserData,


### PR DESCRIPTION
## 개요

관심 빌딩을 추가하고 삭제하는 기능을 추가했습니다.
그와 연계하여 관심목록에 유저의 관심빌딩이 있으면 목록으로 나오게 했습니다.
작업을 하다, 지도 클러스터가 중복으로 나오는 오류를 발견하여 고쳤습니다.

## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

아이콘으로 된 버튼을 누르면 axios, dispatch 두 메소드가 실행되어 db와 리덕스 두 정보 모두가 바뀌게 됩니다.
그와 동시에 빈 하트와 채워진 하트를 상태로 구분하게 만들어 상태도 바뀌게 해놓았습니다.


```js

      await useAxios(`users/user/favorites/buildings/${buildingId}`, 'delete');

      setUserFavorite(false);
      dispatch(deleteUserFavoriteBuilding(buildingId));

```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [x] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항

백엔드와 연계 테스트 완료입니다.
