### PR TITLE
캔버스를 지정하고, 그 위에 터치이벤트로 Drawing 기능 구현완료

### DIFF
--- a/src/pages/SigningDocument.js
+++ b/src/pages/SigningDocument.js
@@ -1,0 +1,96 @@
+import { useRef, useLayoutEffect } from 'react';
+
+export default function SigningDocument() {
+  const ref = useRef();
+
+  useLayoutEffect(() => {
+    const canvas = ref.current;
+    const ctx = canvas.getContext('2d');
+    const color = '#000000';
+
+    let touchesArray = [];
+
+    const handleTouchStart = (event) => {
+      event.preventDefault();
+      const touches = event.changedTouches;
+
+      for (let i = 0; i < touches.length; i++) {
+        touchesArray.push(touches[i]);
+
+        ctx.beginPath();
+        ctx.fillStyle = color;
+        ctx.fill();
+      }
+    };
+
+    const handleTouchMove = (event) => {
+      event.preventDefault();
+      const touches = event.changedTouches;
+
+      for (let i = 0; i < touches.length; i++) {
+        const index = ongoingTouchIndexById(touches[i].identifier);
+
+        if (index >= 0) {
+          ctx.beginPath();
+          ctx.moveTo(touchesArray[index].pageX, touchesArray[index].pageY);
+          ctx.lineTo(touches[i].pageX, touches[i].pageY);
+          ctx.lineWidth = 4;
+          ctx.strokeStyle = color;
+          ctx.stroke();
+
+          touchesArray.splice(index, 1, touches[i]);
+        }
+      }
+    };
+
+    const handleTouchEnd = (event) => {
+      event.preventDefault();
+      const touches = event.changedTouches;
+
+      for (let i = 0; i < touches.length; i++) {
+        let index = ongoingTouchIndexById(touches[i].identifier);
+
+        if (index >= 0) {
+          ctx.lineWidth = 4;
+          ctx.fillStyle = color;
+          ctx.beginPath();
+          ctx.moveTo(touchesArray[index].pageX, touchesArray[index].pageY);
+          ctx.lineTo(touches[i].pageX, touches[i].pageY);
+
+          touchesArray.splice(index, 1);
+        }
+      }
+    };
+
+    const handleTouchCancel = (event) => {
+      event.preventDefault();
+      const touches = event.changedTouches;
+
+      for (let i = 0; i < touches.length; i++) {
+        let index = ongoingTouchIndexById(touches[i].identifier);
+
+        touchesArray.splice(index, 1);
+      }
+    };
+
+    function ongoingTouchIndexById(_id) {
+      for (let i = 0; i < touchesArray.length; i++) {
+        if (touchesArray[i].identifier == _id) {
+          return i;
+        }
+      }
+      return;
+    }
+
+    canvas.addEventListener('touchstart', handleTouchStart);
+    canvas.addEventListener('touchend', handleTouchEnd);
+    canvas.addEventListener('touchmove', handleTouchMove);
+    canvas.addEventListener('touchcancel', handleTouchCancel);
+  }, []);
+
+  return (
+    <>
+      <canvas ref={ref} width='300' height='300'></canvas>
+    </>
+  );
+}

--- a/src/routes/Authorized.js
+++ b/src/routes/Authorized.js
@@ -5,6 +5,7 @@ import Main from '../pages/Main';
 import SearchPlace from '../pages/SearchPlace';
 import MyPage from '../pages/MyPage';
 import MyFavoriteRegion from '../pages/FavoriteRegion';
+import SigningDocument from '../pages/SigningDocument';
 
 export default function Authorized() {
   return (
@@ -16,6 +17,7 @@ export default function Authorized() {
       <Route path='/search/:place' element={<SearchPlace />} />
       <Route path='/mypage' element={<MyPage />} />
       <Route path='/favoriteregion' element={<MyFavoriteRegion />} />
+      <Route path='/sign' element={<SigningDocument />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## 개요

새로 페이지를 만들고, 그 위에 캔버스로 Drawing하는 기능입니다.
![drawing](https://user-images.githubusercontent.com/62933450/173855402-ae7b426e-0cca-4b76-9b87-1d786f8f5fe1.gif)



## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점
캔버스에 touch start 이벤트를 달아, 시작때 path를 시작하게 했습니다.
그리고, touches 배열에 터치된 이벤트의 정보들을 담아, canvas 메소드를 통해
라인을 따라가고, 그리게 했습니다.

```js
canvas.addEventListener('touchstart', handleTouchStart);
canvas.addEventListener('touchend', handleTouchEnd);
canvas.addEventListener('touchmove', handleTouchMove);
canvas.addEventListener('touchcancel', handleTouchCancel);
```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [x] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항
페이지에 코드를 적었습니다.
추후 기능 구현후 관심사 분리 할 예정입니다.
window.addeventlistener 또한 리팩토링할 예정입니다.
