### PR TITLE
Pdf백그라운드 및 캔버스안에서 그릴 수 있는 영역제어 완료

### DIFF
--- a/src/pages/SigningDocument.js
+++ b/src/pages/SigningDocument.js
@@ -1,12 +1,24 @@
-import { useRef, useLayoutEffect } from 'react';
+import { useRef, useEffect } from 'react';
 
 export default function SigningDocument() {
-  const ref = useRef();
+  const ref = useRef(null);
+  const image = new Image();
 
-  useLayoutEffect(() => {
+  image.height = '750px';
+  image.width = '100%';
+  image.src =
+    'https://search.pstatic.net/common/?src=http%3A%2F%2Fblogfiles.naver.net%2FMjAyMTAzMTdfOTgg%2FMDAxNjE1OTcyMzM0MDE0.P1nvKfXOCW_XKpIpVZuJ6RpICT8M2m-4-qbpMPBvhRcg.-27LrnlmDYJCEzucXFXsa3SFAT0Wse5KoxcDGRRI-3Eg.PNG.julian2020%2F%25B4%25EB%25B8%25AE%25C0%25CE_%25C0%25A7%25C0%25D3%25C0%25E5_%25283%2529.png&type=sc960_832';
+
+  useEffect(() => {
+    if (!ref) return;
+
     const canvas = ref.current;
     const ctx = canvas.getContext('2d');
     const color = '#000000';
+    ctx.drawImage(image, 0, 0, 350, 750);
+    ctx.strokeRect(170, 351, 130, 130);
+    const input = document.createElement('input');
+    // input.createTextNode('한경훈');
 
     let touchesArray = [];
 
@@ -15,7 +27,14 @@ export default function SigningDocument() {
       const touches = event.changedTouches;
 
       for (let i = 0; i < touches.length; i++) {
-        touchesArray.push(touches[i]);
+        if (
+          touches[i].clientX < 300 &&
+          170 < touches[i].clientX &&
+          touches[i].clientY < 481 &&
+          351 < touches[i].clientY
+        ) {
+          touchesArray.push(touches[i]);
+        }
 
         ctx.beginPath();
         ctx.fillStyle = color;
@@ -28,17 +47,24 @@ export default function SigningDocument() {
       const touches = event.changedTouches;
 
       for (let i = 0; i < touches.length; i++) {
-        const index = ongoingTouchIndexById(touches[i].identifier);
+        if (
+          touches[i].clientX < 300 &&
+          170 < touches[i].clientX &&
+          touches[i].clientY < 481 &&
+          351 < touches[i].clientY
+        ) {
+          const index = ongoingTouchIndexById(touches[i].identifier);
 
-        if (index >= 0) {
-          ctx.beginPath();
-          ctx.moveTo(touchesArray[index].pageX, touchesArray[index].pageY);
-          ctx.lineTo(touches[i].pageX, touches[i].pageY);
-          ctx.lineWidth = 4;
-          ctx.strokeStyle = color;
-          ctx.stroke();
+          if (index >= 0) {
+            ctx.beginPath();
+            ctx.moveTo(touchesArray[index].pageX, touchesArray[index].pageY);
+            ctx.lineTo(touches[i].pageX, touches[i].pageY);
+            ctx.lineWidth = 4;
+            ctx.strokeStyle = color;
+            ctx.stroke();
 
-          touchesArray.splice(index, 1, touches[i]);
+            touchesArray.splice(index, 1, touches[i]);
+          }
         }
       }
     };
@@ -86,11 +112,11 @@ export default function SigningDocument() {
     canvas.addEventListener('touchend', handleTouchEnd);
     canvas.addEventListener('touchmove', handleTouchMove);
     canvas.addEventListener('touchcancel', handleTouchCancel);
-  }, []);
+  }, [ref]);
 
   return (
     <>
-      <canvas ref={ref} width='300' height='300'></canvas>
+      <canvas ref={ref} width='350px' height='750px'></canvas>
     </>
   );
 }

--- a/src/routes/Unauthorized.js
+++ b/src/routes/Unauthorized.js
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 
 import Login from '../pages/Login';
 import LoginFallback from '../components/LoginFallback';
+import SigningDocument from '../pages/SigningDocument';
 
 export default function Unauthorized() {
   return (
@@ -10,6 +11,7 @@ export default function Unauthorized() {
         <Route path='/' element={<Navigate replace to='/login' />} />
         <Route path='/login' element={<Login />}>
           <Route path='github' element={<LoginFallback />} />
+          <Route path='/sign' element={<SigningDocument />} />
         </Route>
       </Routes>
     </>


### PR DESCRIPTION
## 개요

캔버스안에 백그라운드로 pdf 파일을 설정했습니다.
![drawing](https://user-images.githubusercontent.com/62933450/173884993-c288a916-c099-42b4-92b6-5d569e177501.gif)

그후 캔버스기능으로 사각형을 그리고 , 그 좌표를 구해 
그안에서만 캔버스의 드로잉 기능이 실행되게 했습니다.
touchevent의 좌표를 통해 제어했습니다.


## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점
touch이벤트들이 발동할때, 좌표를 통해 제어했습니다.
만약 반응형으로 하고싶다면, 숫자를 vp, vh 등으로 처리하면 가능할 것 같습니다.



```js
touches[i].clientX < 300 &&
          170 < touches[i].clientX &&
          touches[i].clientY < 481 &&
          351 < touches[i].clientY
```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [x] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항

기능 구현 전부 완료시 리팩토링 진행 예정입니다.
