### PR TITLE
계약서리스트및 정보요청 구현완료

### DIFF
--- a/src/components/ContractList.js
+++ b/src/components/ContractList.js
@@ -1,0 +1,41 @@
+import { useState, useEffect } from 'react';
+import useAxios from '../hooks/useAxios';
+
+export default function ContractList() {
+  const [contract, setContract] = useState();
+
+  useEffect(() => {
+    (async () => {
+      const contractArray = await useAxios('/users/user/contract', 'get');
+      console.log(contractArray.contract);
+      setContract(contractArray.contract);
+    })();
+  }, []);
+
+  const handleOpenPdf = (event) => {
+    const url = event.target.id;
+    const iframe =
+      "<iframe width='100%' height='100%' src='" + url + "'></iframe>";
+    const newTap = window.open();
+    newTap.document.open();
+    newTap.document.write(iframe);
+    newTap.document.close();
+  };
+
+  return (
+    <>
+      <div>계약서</div>
+      {contract &&
+        contract.map((doc, index) => {
+          return (
+            <>
+              <div key={index} id={doc} onClick={handleOpenPdf}>
+                {index}번째 계약서
+              </div>
+              <br></br>
+            </>
+          );
+        })}
+    </>
+  );
+}

--- a/src/pages/MyPage.js
+++ b/src/pages/MyPage.js
@@ -1,12 +1,14 @@
 import FavoriteBuildings from '../components/FavoriteBuildings';
 import UserProfile from '../components/UserProfile';
 import NavBar from '../components/NavBar';
+import ContractList from '../components/ContractList';
 
 export default function MyPage() {
   return (
     <>
       <UserProfile />
       <FavoriteBuildings />
+      <ContractList />
       <NavBar />
     </>
   );

--- a/src/pages/SigningDocument.js
+++ b/src/pages/SigningDocument.js
@@ -1,14 +1,17 @@
 import { useRef, useEffect, useState } from 'react';
-
 import { jsPDF } from 'jspdf';
+import { useNavigate } from 'react-router-dom';
+
 import SubmitModal from '../components/SubmitModal';
+import useAxios from '../hooks/useAxios';
 
 export default function SigningDocument() {
-  const ref = useRef();
   const image = new Image();
   image.height = '750px';
   image.width = '100%';
   image.src = 'img/doc.png';
+
+  const ref = useRef();
   const [citizenNumber, setCitizenNumber] = useState(0);
   const [name, setName] = useState('');
   const [showModal, setShowModal] = useState(false);
@@ -16,7 +19,8 @@ export default function SigningDocument() {
   const year = date.getFullYear();
   const month = date.getMonth();
   const day = date.getDate();
-  console.log(image);
+  const navigate = useNavigate();
+
   useEffect(() => {
     const canvas = ref.current;
     const ctx = canvas.getContext('2d');
@@ -139,7 +143,7 @@ export default function SigningDocument() {
     ctx.clearRect(174, 351, 120, 120);
   };
 
-  const saveCanvasData = () => {
+  const saveCanvasData = async () => {
     const canvas = ref.current;
     const ctx = canvas.getContext('2d');
     ctx.fillText(name, 135, 415, 30);
@@ -151,6 +155,12 @@ export default function SigningDocument() {
     doc.addImage(canvasData, 'JPEG', 0, 0, 200, 200);
     const pdfURI = doc.output('datauristring');
     doc.save('contract.pdf');
+
+    await useAxios('/users/user/contract', 'post', {
+      contract: pdfURI,
+    });
+
+    navigate('/');
   };
 
   return (
@@ -184,7 +194,7 @@ export default function SigningDocument() {
             width: 80,
             fontSize: '4px',
           }}
-          onClick={saveCanvasData}>
+          onClick={() => setShowModal(true)}>
           제출하기
         </button>
         <input

--- a/src/routes/Unauthorized.js
+++ b/src/routes/Unauthorized.js
@@ -2,7 +2,6 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 
 import Login from '../pages/Login';
 import LoginFallback from '../components/LoginFallback';
-import SigningDocument from '../pages/SigningDocument';
 
 export default function Unauthorized() {
   return (
@@ -11,7 +10,6 @@ export default function Unauthorized() {
         <Route path='/' element={<Navigate replace to='/login' />} />
         <Route path='/login' element={<Login />}>
           <Route path='github' element={<LoginFallback />} />
-          <Route path='/sign' element={<SigningDocument />} />
         </Route>
       </Routes>
     </>


### PR DESCRIPTION
## 개요
크롬에서 Not allowed to navigate top frame to data URL 이슈가 있습니다.
이를 해결했습니다
계약서 리스트를 표시해주는 기능입니다.
이외 저장하는 기능과 정보 업데이트, 받아오는 요청까지 구현했습니다.
전부 pdf로 받아옵니다.

## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

Not allowed to navigate top frame to data URL:
이슈가 있어 새탭을 띄우고 iframe으로 넣는 식으로 해결했습니다.

```js
const url = event.target.id;
const iframe =
      "<iframe width='100%' height='100%' src='" + url + "'></iframe>";
const newTap = window.open();

newTap.document.open();
newTap.document.write(iframe);
newTap.document.close();
```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [x] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항

Not allowed to navigate top frame to data URL: 이슈 한번 보시면 좋을것 같습니다
