### PR TITLE
바텀슬라이드 터치 스크롤 구현

### DIFF
--- a/src/components/BottomSheet.js
+++ b/src/components/BottomSheet.js
@@ -1,17 +1,34 @@
 import useBottomSheet from '../hooks/useBottomSheet';
+import { useState } from 'react';
 
 import './BottomSheet.css';
 
 function BottomSheet() {
   const { sheetArea, contentArea } = useBottomSheet();
+  const [touchY, setTouchY] = useState(0);
   const test = new Array(70).fill(1);
+
+  const handleTouchMove = (event) => {
+    for (let i = 0; i < event.touches.length; i++) {
+      if (event.touches[i].clientY > touchY) {
+        contentArea.current.scrollTop -= 20;
+      } else if (event.touches[i].clientY < touchY) {
+        contentArea.current.scrollTop += 20;
+      }
+
+      setTouchY(event.touches[i].clientY);
+    }
+  };
 
   return (
     <div className='bottomsheet' ref={sheetArea}>
       <div className='bottomsheet-header'>
         <div className='handle' />
       </div>
-      <ul className='bottomsheet-content' ref={contentArea}>
+      <ul
+        className='bottomsheet-content'
+        ref={contentArea}
+        onTouchMove={handleTouchMove}>
         {test.map((e, i) => {
           return <li key={i}>{i}</li>;
         })}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -101,7 +101,7 @@ export default function Map() {
       </div>
       <div className='background-container'>
         <div className='graph-container'>
-          <div>VP avg graph(1,000,000Won)</div>
+          <div>Graph(백만)</div>
           <PriceGraph data={graphData}></PriceGraph>
         </div>
       </div>

--- a/src/pages/SearchPlace.js
+++ b/src/pages/SearchPlace.js
@@ -7,6 +7,7 @@ export default function SearchPlace() {
     <>
       <Map />
       <NavBar />
+      <BottomSheet />
     </>
   );
 }


### PR DESCRIPTION
## 개요
![Recording 2022-06-17 at 00 42 24](https://user-images.githubusercontent.com/62933450/174110178-ce6527e4-09dc-48dc-a339-a986426e2a9f.gif)


바텀슬라이드 내부의 스크롤을 구현했습니다.
touch 이벤트의 좌표를 이용해서 구현했습니다.
start, move, end, cancel 네가지 이벤트에 따라서 많은 경우의 수를 직접 테스트 하였으나
완벽하게 사용자가 이용하기에 딱맞는것을 찾지 못했습니다.
시간이 있으면 조금 더 사용자 환경에서 테스트 해보겠습니다.

## PR Type

- [ ] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [x] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

- 변경된 코드에서 가장 핵심이 되는 부분을 설명해 주세요. 이미지 파일이나 코드를 첨부해주시면 더 좋습니다.
touchmove이벤트 내에서 각 터치들의 Y좌표값을 찾아서 scolltop에 입력해주는 방식입니다.
start move end 이벤트 모두 좌표를 저장하고 각각 diff를 구한 후 scrolltop 에 입력해주는 방식과 고민했으나
이 방식이 스크롤 튀는 현상이 아예 없어 고정 값으로 움직이는 방식을 채택했습니다.

```js
 for (let i = 0; i < event.touches.length; i++) {
      if (event.touches[i].clientY > touchY) {
        contentArea.current.scrollTop -= 20;
      } else if (event.touches[i].clientY < touchY) {
        contentArea.current.scrollTop += 20;
      }

      setTouchY(event.touches[i].clientY);
```

## 자가 체크리스트

- [ ] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [ ] PR 이전에 코드를 자가점검 했습니다.

- [ ] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [ ] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [ ] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [ ] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항

사용자가 강하게 스크롤을 당기거나 하는 사항에 취약점이 있습니다.
