### PR TITLE
바텀시트의 에러픽스와 일반매물 클러스터 기능 추가 

### DIFF
--- a/src/components/BottomSheet.js
+++ b/src/components/BottomSheet.js
@@ -3,10 +3,9 @@ import { useState } from 'react';
 
 import './BottomSheet.css';
 
-function BottomSheet() {
+function BottomSheet(props) {
   const { sheetArea, contentArea } = useBottomSheet();
   const [touchY, setTouchY] = useState(0);
-  const test = new Array(70).fill(1);
 
   const handleTouchMove = (event) => {
     for (let i = 0; i < event.touches.length; i++) {
@@ -25,14 +24,18 @@ function BottomSheet() {
       <div className='bottomsheet-header'>
         <div className='handle' />
       </div>
-      <ul
-        className='bottomsheet-content'
-        ref={contentArea}
-        onTouchMove={handleTouchMove}>
-        {test.map((e, i) => {
-          return <li key={i}>{i}</li>;
-        })}
-      </ul>
+
+      <div>이 지역 경매 매물</div>
+      {props.data && (
+        <ul
+          className='bottomsheet-content'
+          ref={contentArea}
+          onTouchMove={handleTouchMove}>
+          {props.data.auctions.map((e, i) => {
+            return <li key={i}>{i}</li>;
+          })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -4,12 +4,11 @@ import { addUserFavoriteRegion } from '../store/userSlice';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { BsSearch } from 'react-icons/bs';
 
-import { getLocation } from '../utils/location';
-
 import useInput from '../hooks/useInput';
 import useMap from '../hooks/useMap';
 import useAxios from '../hooks/useAxios';
 import PriceGraph from '../components/PriceGraph';
+import BottomSheet from '../components/BottomSheet';
 
 import './Map.scss';
 
@@ -25,7 +24,7 @@ export default function Map() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const [showAll, setShowAll, currentAddress, graphData] = useMap(
+  const { showAll, setShowAll, currentAddress, graphData, buildings } = useMap(
     position,
     type,
     mapElement,
@@ -105,6 +104,7 @@ export default function Map() {
           <PriceGraph data={graphData}></PriceGraph>
         </div>
       </div>
+      <BottomSheet data={buildings} />
     </>
   );
 }

--- a/src/components/PriceGraph.js
+++ b/src/components/PriceGraph.js
@@ -5,29 +5,32 @@ import { getMinMaxData } from '../utils/graph';
 
 export default function PriceGraph(data) {
   const svgRef = useRef(null);
+  const color = [];
 
   useEffect(() => {
-    const width = 360;
+    const width = '100vw';
     const height = 150;
     const barHeight = (height - 20) / 3;
     const [min, max] = getMinMaxData(data);
-    const scale = d3.scaleLinear().domain([min, max]).range([50, 240]);
-    const color = [];
+    const scale = d3.scaleLinear().domain([min, max]).range([50, 210]);
+
+    if (data.data == []) return;
+    if (!data.data) return;
 
     for (let i = 0; i < data.data.length; i++) {
       if (parseInt(data.data[i].value) === max) {
-        color.push('#1864ab');
+        color.push('#1363DF');
       } else if (parseInt(data.data[i].value) === min) {
-        color.push('#4dabf7');
+        color.push('#7FB5FF');
       } else {
-        color.push('#a5d8ff');
+        color.push('#DFF6FF');
       }
     }
 
     const graph = d3
       .select(svgRef.current)
       .append('svg')
-      .attr('width', '100vw')
+      .attr('width', '350px')
       .attr('height', '30vh');
 
     const bar = graph
@@ -37,7 +40,7 @@ export default function PriceGraph(data) {
       .enter()
       .append('g')
       .attr('transform', (d, i) => {
-        return `translate(10, ${i * (height / 3)})`;
+        return `translate(50, ${i * (height / 3)})`;
       });
 
     bar
@@ -67,7 +70,7 @@ export default function PriceGraph(data) {
       .attr('z-index', '100')
       .text((data) => {
         if (isNaN(data.value)) return;
-        return parseInt(data.value);
+        return parseInt(data.value) / 100 + '억원';
       });
 
     bar
@@ -85,5 +88,5 @@ export default function PriceGraph(data) {
     };
   }, [data]);
 
-  return <svg id='graph' ref={svgRef}></svg>;
+  return <svg id='graph' width={'350px'} ref={svgRef}></svg>;
 }

--- a/src/hooks/useBottomSheet.js
+++ b/src/hooks/useBottomSheet.js
@@ -121,25 +121,25 @@ function useBottomSheet() {
     sheetArea.current.addEventListener('touchmove', handleTouchMove);
     sheetArea.current.addEventListener('touchend', handleTouchEnd);
 
-    return () => {
-      sheetArea.current.removeEventListener('touchstart', handleTouchStart);
-      sheetArea.current.removeEventListener('touchmove', handleTouchMove);
-      sheetArea.current.removeEventListener('touchend', handleTouchEnd);
-    };
+    // return () => {
+    //   sheetArea.current.removeEventListener('touchstart', handleTouchStart);
+    //   sheetArea.current.removeEventListener('touchmove', handleTouchMove);
+    //   sheetArea.current.removeEventListener('touchend', handleTouchEnd);
+    // };
   }, []);
 
-  useEffect(() => {
-    const handleTouchStart = (event) => {
-      event.preventDefault();
-      metrics.current.isContentAreaTouched = true;
-    };
+  // useEffect(() => {
+  //   const handleTouchStart = (event) => {
+  //     event.preventDefault();
+  //     metrics.current.isContentAreaTouched = true;
+  //   };
 
-    contentArea.current.addEventListener('touchstart', handleTouchStart);
+  //   contentArea.current.addEventListener('touchstart', handleTouchStart);
 
-    return () => {
-      contentArea.current.removeEventListener('touchstart', handleTouchStart);
-    };
-  }, []);
+  //   return () => {
+  //     contentArea.current.removeEventListener('touchstart', handleTouchStart);
+  //   };
+  // }, []);
 
   return {
     sheetArea,

--- a/src/hooks/useMap.js
+++ b/src/hooks/useMap.js
@@ -13,6 +13,7 @@ export default function useMap(position, type, mapElement) {
   const [graphData, setGraphData] = useState({});
   const [isMap, setIsMap] = useState(false);
   const [newType, setNewType] = useState();
+  const [buildings, setBuildings] = useState(false);
   const infoWindowArray = [];
   const auctionMarkers = [];
   const forSalesArray = [];
@@ -113,6 +114,7 @@ export default function useMap(position, type, mapElement) {
       );
 
       setGraphData(getGraphData(buildings));
+      setBuildings(buildings);
       setCurrentCenter(centerPoint);
       setAuctionsMarker(map, buildings.auctions);
       forSalesArray.push(...buildings.forSales);
@@ -239,5 +241,5 @@ export default function useMap(position, type, mapElement) {
     return buildings;
   };
 
-  return [showAll, setShowAll, currentAddress, graphData];
+  return { showAll, setShowAll, currentAddress, graphData, buildings };
 }

--- a/src/hooks/useMap.js
+++ b/src/hooks/useMap.js
@@ -21,6 +21,7 @@ export default function useMap(position, type, mapElement) {
   const kakao = window.kakao;
   const navigate = useNavigate();
   let cluster;
+  let commonCluster;
 
   useEffect(() => {
     const mapContainer = mapElement.current;
@@ -35,14 +36,22 @@ export default function useMap(position, type, mapElement) {
     const map = !isMap ? new kakao.maps.Map(mapContainer, mapOptions) : isMap;
     const geocoder = new kakao.maps.services.Geocoder();
     const ps = new kakao.maps.services.Places();
-
+    map.setMinLevel(4);
+    map.setMaxLevel(7);
     const clusterer = new kakao.maps.MarkerClusterer({
       map: map,
       averageCenter: true,
       minLevel: 7,
     });
 
+    const commonClusterer = new kakao.maps.MarkerClusterer({
+      map: map,
+      averageCenter: true,
+      minLevel: 7,
+    });
+
     cluster = clusterer;
+    commonCluster = commonClusterer;
 
     if (position) {
       const coord = new kakao.maps.LatLng(position);
@@ -195,6 +204,7 @@ export default function useMap(position, type, mapElement) {
       infoWindowArray.push(infoWindow);
       forSalesMarkersArray.push(forSalesMarker);
       forSalesMarker.setMap(map);
+      commonCluster.addMarker(forSalesMarker);
 
       kakao.maps.event.addListener(forSalesMarker, 'click', () => {
         closeInfoWindow();

--- a/src/pages/SearchPlace.js
+++ b/src/pages/SearchPlace.js
@@ -1,13 +1,11 @@
 import Map from '../components/Map';
 import NavBar from '../components/NavBar';
-import BottomSheet from '../components/BottomSheet';
 
 export default function SearchPlace() {
   return (
     <>
       <Map />
       <NavBar />
-      <BottomSheet />
     </>
   );
 }

--- a/src/utils/graph.js
+++ b/src/utils/graph.js
@@ -6,6 +6,8 @@ export function getGraphData(data) {
   let lowestPriceSum = 0;
   let averagePriceSum = 0;
 
+  if (!data.auctions) return;
+
   for (let i = 0; i < data.auctions.length; i++) {
     tempConnoisseur = data.auctions[i].connoisseur.replaceAll(',', '');
     tempConnoisseur = data.auctions[i].connoisseur.replaceAll('원', '');
@@ -33,7 +35,10 @@ export function getGraphData(data) {
 
 export function getMinMaxData(data) {
   let max = 0;
-  let min = 0;
+  let min = Infinity;
+
+  if (!data.data) return [min, max];
+  if (data.data == []) return [min, max];
 
   for (let i = 0; i < data.data.length; i++) {
     if (isNaN(data.data[i].value)) break;


### PR DESCRIPTION
## 개요

바텀시트를 클릭하면 에러가 나는 현상을 고쳤습니다.
터치이벤트가 겹치는 오류가 있었습니다.
그 외에 지도 일반매물에 대한 클러스터 기능과 
너무많은 마커가 불러지는것을 방지하기 위해서 지도 축소 레벨을 제한시켰습니다.

## PR Type

- [x] 버그 픽스 / 사소한 변경 (앱 실행에 영향을 주지 않는 변경을 의미합니다.)

- [ ] 기능 구현

- [ ] 중요한 변경 사항 (앱의 기능이 변화하거나 앱 실행에 직접적인 영향을 주는 수준의 변경을 의미합니다.)

- [ ] 변경 사항으로 인해 문서를 업데이트 해야 합니다.


## 주요 구현점 / 변경점

터치 이벤트가 겹치는 부분을 없앴습니다. 


```js

```

## 자가 체크리스트

- [x] 이 프로젝트에서 협의된 스타일 가이드라인을 따랐습니다.

- [x] PR 이전에 코드를 자가점검 했습니다.

- [ ] 코드에 이해하기 어려운 부분에 주석을 달았습니다.

- [x] (문서 변경이 필요한 경우) 문서에 현재 코드 변경에 관한 내용을 새로 반영했습니다.

- [x] 현재 코드에서 아무런 경고 메세지가 뜨지 않습니다.

- [x] 변경 사항이 다른 모듈들에게 영향을 주지 않습니다.


## 코드 리뷰시 주의사항
다른 에러가 발견될 시 알려주세요!
